### PR TITLE
Install aria2c if unavailable; don't prompt

### DIFF
--- a/apt-fast
+++ b/apt-fast
@@ -6,20 +6,13 @@ ARCHLIST=${ARCHDIR}/apt-fast_$$.list
 
 # Test if aria2 is installed
 if [ ! -x /usr/bin/aria2c ]; then
-  echo "aria2 is not installed, perform installation? (y/n)"
-  read -r ops
-  case ${ops,,} in
-  y) if apt-get install aria2 -y; then
+  echo "aria2 is not installed, performing installation..."
+  if apt-get install aria2 -y; then
     echo "aria2 installed"
   else
     echo "Unable to install the aria2. Are you sudo?"
-    exit
-  fi ;;
-  n)
-    echo "Aborting script"
     exit 1
-    ;;
-  esac
+  fi
 fi
 
 # If the user entered arguments contain upgrade, install, or dist-upgrade


### PR DESCRIPTION
Install aria2c when t's missing instead of waiting on user approval/input